### PR TITLE
Handle missing vertex colors in aiMesh gracefully

### DIFF
--- a/MeshUnpacker/Source/Parser/Mesh/assimp_to_internal.cpp
+++ b/MeshUnpacker/Source/Parser/Mesh/assimp_to_internal.cpp
@@ -513,10 +513,20 @@ void assimp_to_lodContainers(PARSER::Mesh& mesh, PARSER::Mesh& reference_mesh) {
 				vertexAttribute.vertexGroups.vertexGroupIndex3 = 0;
 				vertexAttribute.vertexGroups.vertexGroupIndex4 = 0;
 
-				vertexAttribute.color.r = aiMesh->mColors[0][vertexAttributeCounter].r * 255;
-				vertexAttribute.color.g = aiMesh->mColors[0][vertexAttributeCounter].g * 255;
-				vertexAttribute.color.b = aiMesh->mColors[0][vertexAttributeCounter].b * 255;
-				vertexAttribute.color.a = aiMesh->mColors[0][vertexAttributeCounter].a * 255;
+				if (aiMesh->HasVertexColors(0))
+				{
+					vertexAttribute.color.r = aiMesh->mColors[0][vertexAttributeCounter].r * 255;
+					vertexAttribute.color.g = aiMesh->mColors[0][vertexAttributeCounter].g * 255;
+					vertexAttribute.color.b = aiMesh->mColors[0][vertexAttributeCounter].b * 255;
+					vertexAttribute.color.a = aiMesh->mColors[0][vertexAttributeCounter].a * 255;
+				}
+				else
+				{
+					vertexAttribute.color.r = 255;
+					vertexAttribute.color.g = 255;
+					vertexAttribute.color.b = 255;
+					vertexAttribute.color.a = 255;
+				}
 
 				for (int i = 0; i < aiMesh->GetNumUVChannels(); ++i) {
 					// Assuming that the fbx will use floats instead of those fucking shorts...


### PR DESCRIPTION
Previously, the code assumed that vertex colors were always present, which could lead to errors if `aiMesh->mColors[0]` was null. Added a conditional check to verify if vertex colors are available using `aiMesh->HasVertexColors(0)`.

If vertex colors are present, the values are assigned as before. If not, a fallback sets the vertex color to white (`r = 255, g = 255, b = 255, a = 255`).

This change improves robustness and prevents potential crashes or undefined behavior when vertex colors are missing.